### PR TITLE
Duplicate new message in default

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -38,6 +38,10 @@ Create a language map base on the default messages. If the `defaultLang` paramet
 
 Create a new language map containing given messages merged to current definition. The `additional` parameter provides messages which may replace existing strings, create new languages or even extend the string list (e.g. plugin specific messages).
 
+The method will raise an exception if the `additional` parameter contains a language which is not already in the original object and does not contain the `$` entry.
+
+If a message is given in any language while it does not exist in default language, the entry will be duplicated in the default language.
+
 ## contains(lang: string): boolean
 
 Indicate if the language map contains the given language. This cannot be used to test existence of `default` language, but default language is always present.

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -147,7 +147,7 @@ export const messages: PartialMessages<typeof defLang> = {
 }
 ```
 
-Note that, by default, when the `Français (Canada)` will be selected, the `fr_ca` preference will be given to the `Intl` object which will automatically add the `fr` preference as second choice, which will correctly fill the translations (this is the result of the `createGenerics` option in the constructor and in the `$changePreferences()` method). En dernier choix, si la traduction n'est toujours pas trouvée, c'est la langue par défaut qui est utilisée.
+Note that, by default, when the `Français (Canada)` will be selected, the `fr_ca` preference will be given to the `Intl` object which will automatically add the `fr` preference as second choice, which will correctly fill the translations (this is the result of the `createGenerics` option in the constructor and in the `$changePreferences()` method). As a last choice, if translation is still not found, the default language is used.
 
 ## Index file
 

--- a/doc/fr/api.md
+++ b/doc/fr/api.md
@@ -38,6 +38,10 @@ Créer une table de langues basée sur les messages par défaut. Si le paramètr
 
 Créer une nouvelle table de langues contenant les messages fournis, fusionnés avec la définition actuelle. Le paramètre `additional` fourni des messages qui peuvent potentiellement remplacer des messages existants, créer de nouvelles langues ou même étendre la liste des messages (cas des messages spécifiques pour une extension, par exemple).
 
+La méthode lèvera une exception si le paramètre `additional` contient une langue qui n'existe pas dans l'objet d'origine et ne contient pas l'entrée `$`.
+
+Si un message est donnée dans une langue quelconque alors qu'il n'existe pas dans la langue par défaut, l'entrée sera dupliquée dans la langue par défaut.
+
 ## contains(lang: string): boolean
 
 Indiquer si la table de langues contient la langue donnée. Cette méthode ne peut pas être utilisée pour tester l'existence de la langue `default`, mais cette langue (par défaut) est toujours présente.

--- a/doc/fr/examples.md
+++ b/doc/fr/examples.md
@@ -147,7 +147,7 @@ export const messages: PartialMessages<typeof defLang> = {
 }
 ```
 
-Notez que par défaut, lorsque le `Français (Canada)` sera sélectionné, la préférence `fr_ca` sera donnée à l'objet `Intl` qui ajoutera automatiquement la préférence `fr` en second choix, ce qui complétera les traductions correctement (c'est le résultat de l'option `createGenerics` du constructeur ou de la méthode `$changePreferences()`). As a last choice, if translation is still not found, the default language is used.
+Notez que par défaut, lorsque le `Français (Canada)` sera sélectionné, la préférence `fr_ca` sera donnée à l'objet `Intl` qui ajoutera automatiquement la préférence `fr` en second choix, ce qui complétera les traductions correctement (c'est le résultat de l'option `createGenerics` du constructeur ou de la méthode `$changePreferences()`). En dernier choix, si la traduction n'est toujours pas trouvée, c'est la langue par défaut qui est utilisée.
 
 ## Fichier d'index
 

--- a/doc/fr/migrate.md
+++ b/doc/fr/migrate.md
@@ -71,4 +71,4 @@ Exemple :
    fr,
 ```
 
-La langue par défaut doit obligatoirement contenir tous les messages disponibles dans les autres langues. Une exception sera levée par la méthode `merge<A extends Messages>(additional: { [key: string]: Partial<A> }): LanguageMap<T & A>` si vous tentez d'ajouter une entrée dans une autre langue alors qu'elle n'existe pas dans la langue par défaut.
+La langue par défaut doit obligatoirement contenir tous les messages disponibles dans les autres langues. Si vous ajoutez une entrée dans une autre langue alors qu'elle n'existe pas dans la langue par défaut, celle-ci sera dupliquée dans la langue par défaut.

--- a/doc/migrate.md
+++ b/doc/migrate.md
@@ -71,4 +71,4 @@ Example :
    fr,
 ```
 
-The default language must contain all the messages available in other languages. An exception will be raised by the `merge<A extends Messages>(additional: { [key: string]: Partial<A> }): LanguageMap<T & A>` method if you try to add an entry in another language while it does not exist in the default one.
+The default language must contain all the messages available in other languages. If you add an entry in another language while it does not exist in the default one, this entry will be duplicated in the default language.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intl-ts",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Internationalization library for TypeScript",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/LanguageMap.spec.ts
+++ b/src/LanguageMap.spec.ts
@@ -104,10 +104,12 @@ describe('LanguageMap', function() {
     )
   })
 
-  it('must fail when adding a message with no default', function() {
-    expect(() =>
-      new LanguageMap({ default: en, en: 'default', fr }).merge({ fr: { unknown: 'broken' } })
-    ).to.throw('LanguageMap: merged message "unknown" has no default')
+  it('must duplicate added message with no default', function() {
+    const testedLanguageMap = new LanguageMap({ default: en, en: 'default', fr }).merge<{
+      $: string
+      unknown: string
+    }>({ fr: { unknown: 'cassé' } })
+    expect(testedLanguageMap.messages().unknown).to.equal('cassé')
   })
 
   it('must succeed when adding a message with provided (unknown) default', function() {

--- a/src/LanguageMap.ts
+++ b/src/LanguageMap.ts
@@ -90,7 +90,7 @@ export class LanguageMap<T extends Messages> {
         }
         Object.keys(messages).forEach(message => {
           if (lang !== 'default' && !(message in _definition.default)) {
-            throw new Error(`LanguageMap: merged message "${message}" has no default`)
+            ;(_definition.default as any)[message] = messages[message]
           }
           ;(_definition[lang] as any)[message] = messages[message]
         })


### PR DESCRIPTION
When a new entry which does not exist in default language is added, this entry is duplicated to default language instead of throwing an exception.